### PR TITLE
Temporarily remove the buildCommand

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,3 @@
 {
-  "buildCommand": "pnpm db:migrate && pnpm db:seed && pnpm build",
   "regions": ["pdx1"]
 }


### PR DESCRIPTION
The sample code is running into the following error:

```
14:53:07.491 Seeding failed: error: schema has been updated by another transaction, please retry: (OC001)
14:53:07.492     at /vercel/path0/node_modules/.pnpm/pg@8.16.3/node_modules/pg/lib/client.js:545:17
14:53:07.493     at process.processTicksAndRejections (node:internal/process/task_queues:103:5)
14:53:07.493     at async main (/vercel/path0/lib/db/seed.ts:56:7) {
14:53:07.493   length: 97,
14:53:07.493   severity: 'ERROR',
14:53:07.495   code: '40001',
14:53:07.495   detail: undefined,
14:53:07.495   hint: undefined,
14:53:07.496   position: undefined,
14:53:07.496   internalPosition: undefined,
14:53:07.496   internalQuery: undefined,
14:53:07.496   where: undefined,
14:53:07.496   schema: undefined,
14:53:07.496   table: undefined,
14:53:07.496   column: undefined,
14:53:07.496   dataType: undefined,
14:53:07.496   constraint: undefined,
14:53:07.496   file: undefined,
14:53:07.497   line: undefined,
14:53:07.497   routine: undefined
14:53:07.497 }
14:53:07.535  ELIFECYCLE  Command failed with exit code 1.
14:53:07.550 Error: Command "pnpm db:migrate && pnpm db:seed && pnpm build" exited with 1
```

This is because the seeding code is picking up a connection which caching the catalog before the migration step. The recommended DSQL fix for this is to retry on these OC001 (OCC errors). I will follow-up with a change to the seed code to do this, but for now we want to unblock creating a vercel project from the sample.