### PR TITLE
Implement retries for seed

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,4 @@
 {
+  "buildCommand": "pnpm db:migrate && pnpm db:seed && pnpm build",
   "regions": ["pdx1"]
 }


### PR DESCRIPTION
I have tested locally and confirmed that this avoids the OCC (optimistic concurrency errors) that we were seeing previously during initial provisioning from the template. It should be safe to re-enable full schema creation and data seeding as part of the template now.